### PR TITLE
Improving deployment and testing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,82 @@
+Contributing to The System Controller 4
+=======================================
+
+Developing
+----------
+
+Prerequisites
+^^^^^^^^^^^^^
+
+The instructions assume that you have ``docker``, ``docker-machine`` and ``docker-compose`` installed and configured properly on your machine. Please refer to the official installation guides if needed:
+
+* Installing docker: https://docs.docker.com/installation/
+* Installing docker-machine: https://docs.docker.com/machine/install-machine/
+* Installing docker-compose: https://docs.docker.com/compose/install/
+
+To verify your installation run:
+
+.. code-block:: bash
+
+    docker run hello-world
+
+The result should be a message similar to this one:
+
+.. code-block:: bash
+
+    Hello from Docker.
+    This message shows that your installation appears to be working correctly.
+
+    To generate this message, Docker took the following steps:
+    1. The Docker client contacted the Docker daemon.
+    2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+    3. The Docker daemon created a new container from that image which runs the
+    executable that produces the output you are currently reading.
+    4. The Docker daemon streamed that output to the Docker client, which sent it
+    to your terminal.
+
+    To try something more ambitious, you can run an Ubuntu container with:
+    $ docker run -it ubuntu bash
+
+    Share images, automate workflows, and more with a free Docker Hub account:
+    https://hub.docker.com
+
+    For more examples and ideas, visit:
+    https://docs.docker.com/userguide/
+
+Finding information about your docker daemon
+""""""""""""""""""""""""""""""""""""""""""""
+
+Run the following command:
+
+.. code-block:: bash
+
+    docker-machine env  $(docker-machine ls --filter state=Running -q)
+
+Running the application
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To start the application using docker-compose:
+
+.. code-block:: bash
+
+    docker-compose up -d
+
+<<<<<<< HEAD
+Then launch your web browser and go to the URL that you discovered in the previous section, with the port 8080. For example on a mac, where toolbox would be installed, the URL would be http://192.168.99.100:8080.
+
+Deploying the application
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deploying the application is done via Ansible. A playbook and the required roles are stored in the ``ansible`` directory at the root of the project.
+
+This part assumes the you have Vagrant setup on your machine. Please refer to the official installation guide if needed:
+
+* Installing Vagrant: http://docs.vagrantup.com/v2/installation/
+
+Running ``vagrant up`` will automatically provision the virtual machine.
+
+In case you need to update or redeploy, you can simply run the ansible playbook again.
+
+.. code-block:: bash
+
+    ansible-playbook --user=vagrant --connection=ssh --timeout=30 --limit='thesystemcontroller' --inventory-file=.vagrant/provisioners/ansible/inventory --sudo -v ansible/provision.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:jessie
+MAINTAINER Rémy Greinhofer <remy.greinhofer@gmail.com>
+
+# Create the directory containing the code.
+RUN mkdir /code
+WORKDIR /code
+
+# Set the environment variables.
+ENV PYTHONPATH $PYTHONPATH:/code
+
+# Update the package list.
+RUN apt-get update \
+
+  # Install packages.
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yyq \
+    build-essential \
+    python \
+    python-dev \
+    python-pip \
+    python-setuptools \
+    python-smbus \
+
+  # Clean up.
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy the requirements.txt file.
+COPY requirements.txt /code/requirements.txt
+COPY test-requirements.txt /code/test-requirements.txt
+
+# Install the pip packages.
+RUN pip install -q -r requirements.txt -r test-requirements.txt
+
+# Expose the port.
+EXPOSE 8888
+
+# Start the application.
+ENTRYPOINT ["python", "wsgi.py"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    # Prefer VirtualBox provider.
+    config.vm.provider "virtualbox"
+
+    # Box configuration.
+    config.vm.box = "debian-jessie"
+    config.vm.box_url = "https://github.com/holms/vagrant-jessie-box/releases/download/Jessie-v0.1/Debian-jessie-amd64-netboot.box"
+
+    # SSH configration.
+    config.ssh.forward_x11 = true
+    config.ssh.forward_agent = true
+
+    # Network configration.
+    config.vm.network "private_network", type: "dhcp"
+
+    # Use the cachier plugin if available.
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+    end
+
+    # Use the landrush plugin if available.
+    if Vagrant.has_plugin?("landrush")
+        config.landrush.enabled = true
+    end
+
+    # Customize the virtualbox provider.
+    config.vm.provider "virtualbox" do |v|
+        v.memory = "1024"
+    end
+
+    # Create the box and provision it.
+    config.vm.define "thesystemcontroller" do |thesystemcontroller|
+        thesystemcontroller.vm.hostname = "thesystemcontroller.vagrant.dev"
+
+        # Configure the port forwarding.
+        thesystemcontroller.vm.network "forwarded_port", host: 8080, guest: 8080, auto_correct: true
+
+        # Provision the box using an Ansible playbook.
+        thesystemcontroller.vm.provision "ansible" do |ansible|
+            ansible.playbook = "ansible/provision.yml"
+            ansible.sudo = true
+            ansible.verbose= ""
+        end
+    end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+library = library:/usr/share/ansible
+roles_path = roles:/etc/ansible/roles

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -1,0 +1,9 @@
+---
+- hosts: thesystemcontroller
+  vars:
+    # Liquidprompt.
+    liquidprompt_apply_all_users: True
+
+  roles:
+    - sbani.liquidprompt
+    - thesystemcontroller

--- a/ansible/roles/thesystemcontroller/README.md
+++ b/ansible/roles/thesystemcontroller/README.md
@@ -1,0 +1,36 @@
+The System Controller
+=====================
+
+Deploys the software on the The System Controller device.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+None.
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+    - hosts: thesystemcontroller
+      roles:
+         - thesystemcontroller
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Rémy Greinhofer <remy.greinhofer@gmail.com>

--- a/ansible/roles/thesystemcontroller/defaults/main.yml
+++ b/ansible/roles/thesystemcontroller/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for thesystemcontroller

--- a/ansible/roles/thesystemcontroller/handlers/main.yml
+++ b/ansible/roles/thesystemcontroller/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for robogardener

--- a/ansible/roles/thesystemcontroller/meta/main.yml
+++ b/ansible/roles/thesystemcontroller/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Rémy Greinhofer
+  description: Deploy the System Controller software
+  license: MIT
+  min_ansible_version: 1.2
+  platforms:
+    - name: Debian
+    - jessie
+  categories:
+    - system
+dependencies: []

--- a/ansible/roles/thesystemcontroller/tasks/main.yml
+++ b/ansible/roles/thesystemcontroller/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Install packages for Debian
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 86400
+  when: ansible_pkg_mgr == 'apt'
+  with_items:
+    - build-essential
+    - ntpdate
+    - python
+    - python-dev
+    - python-pip
+    - python-setuptools
+    - python-smbus
+    - python-virtualenv
+  sudo: yes
+
+- name: Clone the repository
+  git:
+    repo: https://github.com/dsmurl/TheSystemController4.git
+    dest: ~/TheSystemController4
+
+- name: Create python virtual environment
+  command: virtualenv -p python2.7 ~/.venvs/TheSystemController4
+  args:
+    creates: ~/.venvs/TheSystemController4
+  changed_when: False
+
+- name: Install python packages from requirements
+  pip:
+    requirements: ~/TheSystemController4/requirements.txt
+    state: latest
+    virtualenv: ~/.venvs/TheSystemController4
+
+- name: install zuul in virtualenv
+  pip:
+    name: gunicorn
+    state: latest
+    virtualenv: ~/.venvs/TheSystemController4
+
+
+- name: Start the application
+  shell: |
+    . ~/.venvs/TheSystemController4/bin/activate
+    gunicorn -b 0.0.0.0:8080 -w4 wsgi:app &
+  args:
+    chdir: ~/TheSystemController4
+  changed_when: False

--- a/ansible/roles/thesystemcontroller/vars/main.yml
+++ b/ansible/roles/thesystemcontroller/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for thesystemcontroller

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+thesystemcontroller:
+  build: .
+  ports:
+    - "8080:8080"
+  volumes:
+    - .:/code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-gevent
-webapp2
-Jinja2
-python-memcached
-peewee
-ws4py
-webob
-supervisor
+gevent==1.0.2
+Jinja2==2.8
+peewee==2.6.3
+python-memcached==1.57
+supervisor==3.1.3
+webapp2==2.5.2
+WebOb==1.4.1
+ws4py==0.3.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+pbr
+wheel


### PR DESCRIPTION
## Pin versions in requirements.txt

The dependency versions was pinned in the requirements.txt file. A
test-requirements.txt file was created to seperate the dependencies
required to run the application from the other used to test or package it.
## Dockerize the application

Dockerizing the application offers a lot of benefits:
- ease of use
- ease of deployment
- makes it way easier for contributors to start developing
## Add a Vagrantfile to the project

Vagrant is used to test the deployment of the project using the ansible
playbook.
## Create Ansible playbook and role for deploying

An ansible playbook was setup to easy the deployment of the application on
the BeagleBone.

The role robogardener (no 't' in 'robot') prepares the environment by
installing all the required packages and starting the application via a
gunicorn server.
## Add CONTRIBUTION guidelines

The contribution guidelines will help contributor to setup their
environment and provide direction to have their submission merged into the
main repository.

A new section explaining how to deploy the application with ansible and
test it using a VM was added.
